### PR TITLE
fix: downgrade Kotlin JVM target from 21 to 17 for compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.7.0")
+        classpath("com.android.tools.build:gradle:8.7.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -30,12 +30,12 @@ android {
     compileSdk = 35
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     sourceSets {
@@ -57,9 +57,9 @@ android {
             useJUnitPlatform()
 
             testLogging {
-               events "passed", "skipped", "failed", "standardOut", "standardError"
-               outputs.upToDateWhen {false}
-               showStandardStreams = true
+                events "passed", "skipped", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen { false }
+                showStandardStreams = true
             }
         }
     }


### PR DESCRIPTION

This PR fixes a build failure caused by the use of an unsupported Kotlin JVM target version in the file_picker_pro plugin. The plugin was previously configured to use JavaVersion.VERSION_21, which is not supported by the current Flutter/Gradle/Kotlin toolchain.

🛠 **Changes Made**
Downgraded JavaVersion.VERSION_21 to JavaVersion.VERSION_17 in compileOptions.
Set kotlinOptions.jvmTarget to "17".

✅ **Why This Is Needed**
Using JavaVersion.VERSION_21 caused the following error during build:

`Unknown Kotlin JVM target: 21`

This change ensures compatibility with Kotlin 2.1.0 and the Flutter 3.29.2 toolchain, resolving the issue and allowing successful builds.